### PR TITLE
Use non-deprecated start-command

### DIFF
--- a/flood/Dockerfile
+++ b/flood/Dockerfile
@@ -22,4 +22,4 @@ WORKDIR /usr/src/app
 RUN apk add -U --no-cache mediainfo
 COPY --from=build /usr/src/app /usr/src/app
 
-CMD [ "npm", "run", "start:production" ]
+CMD [ "npm", "run", "start" ]


### PR DESCRIPTION
The command "npm run start:production" is deprecated and prints
a deprecation warning when executing. Use the command "npm run
start" that is not deprecated.

```

> flood@1.0.0 start:production /usr/src/app
> UPDATED_SCRIPT=start npm run deprecated-warning && npm start


> flood@1.0.0 deprecated-warning /usr/src/app
> node client/scripts/deprecated-warning.js && sleep 10




    This npm script has been deprecated!
      Use npm script `start` instead.




> flood@1.0.0 start /usr/src/app
> node --use_strict server/bin/start.js

(node:46) ExperimentalWarning: The fs.promises API is experimental
Flood server starting on http://undefined:3000.
```